### PR TITLE
APB 7664 Create new endpoint GET AMLS details by ARN [RM]

### DIFF
--- a/app/uk/gov/hmrc/agentassurance/binders/PathBinders.scala
+++ b/app/uk/gov/hmrc/agentassurance/binders/PathBinders.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.agentassurance.binders
 
 import play.api.mvc.PathBindable
-import uk.gov.hmrc.agentmtdidentifiers.model.Utr
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Utr}
 import uk.gov.hmrc.domain.{Nino, SaAgentReference}
 
 object PathBinders {
@@ -30,5 +30,13 @@ object PathBinders {
     }
 
     override def unbind(key: String, utr: Utr): String = utr.value
+  }
+
+  implicit val arnBinder: PathBindable[Arn] = new PathBindable[Arn] {
+    override def bind(key: String, value: String): Either[String, Arn] = {
+      if(Arn.isValid(value)) Right(Arn(value)) else Left("Invalid ARN")
+    }
+
+    override def unbind(key: String, arn: Arn): String = arn.value
   }
 }

--- a/app/uk/gov/hmrc/agentassurance/controllers/GetAmlsDetailsByArnController.scala
+++ b/app/uk/gov/hmrc/agentassurance/controllers/GetAmlsDetailsByArnController.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.controllers
+
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.agentassurance.auth.AuthActions
+import uk.gov.hmrc.agentassurance.config.AppConfig
+import uk.gov.hmrc.agentassurance.models.{OverseasAmlsDetails, UkAmlsDetails}
+import uk.gov.hmrc.agentassurance.services.AmlsDetailsService
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.http.InternalServerException
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class GetAmlsDetailsByArnController @Inject()(amlsDetailsService: AmlsDetailsService,
+                                              val authConnector: AuthConnector,
+                                              override val controllerComponents: ControllerComponents
+                                             )(implicit val appConfig: AppConfig, ec: ExecutionContext) extends BackendController(controllerComponents) with AuthActions {
+
+  private val strideRoles = Seq(appConfig.manuallyAssuredStrideRole)
+
+  def getAmlsDetails(arn: Arn): Action[AnyContent] =
+    withAffinityGroupAgentOrStride(strideRoles) {
+      request =>
+        amlsDetailsService.getAmlsDetailsByArn(arn).map {
+          case Nil => NotFound // Should this be NoContent as this isn't an client side issue
+          case Seq(amlsDetails@UkAmlsDetails(_, _, _, _, _, _)) => Ok(Json.toJson(amlsDetails))
+          case Seq(overseasAmlsDetails@OverseasAmlsDetails(_, _)) => Ok(Json.toJson(overseasAmlsDetails))
+          case _ => throw new InternalServerException("[getAmlsDetailsByArnController][getAmlsDetails] ARN has both Overseas and UK AMLS details")
+        }
+
+    }
+
+}

--- a/app/uk/gov/hmrc/agentassurance/controllers/GetAmlsDetailsByArnController.scala
+++ b/app/uk/gov/hmrc/agentassurance/controllers/GetAmlsDetailsByArnController.scala
@@ -42,7 +42,7 @@ class GetAmlsDetailsByArnController @Inject()(amlsDetailsService: AmlsDetailsSer
     withAffinityGroupAgentOrStride(strideRoles) {
       request =>
         amlsDetailsService.getAmlsDetailsByArn(arn).map {
-          case Nil => NotFound // Should this be NoContent as this isn't an client side issue
+          case Nil => NoContent
           case Seq(amlsDetails@UkAmlsDetails(_, _, _, _, _, _)) => Ok(Json.toJson(amlsDetails))
           case Seq(overseasAmlsDetails@OverseasAmlsDetails(_, _)) => Ok(Json.toJson(overseasAmlsDetails))
           case _ => throw new InternalServerException("[getAmlsDetailsByArnController][getAmlsDetails] ARN has both Overseas and UK AMLS details")

--- a/app/uk/gov/hmrc/agentassurance/models/AmlsEntity.scala
+++ b/app/uk/gov/hmrc/agentassurance/models/AmlsEntity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,13 @@
 package uk.gov.hmrc.agentassurance.models
 
 import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Utr}
 
-case class OverseasAmlsDetails(supervisoryBody: String, membershipNumber: Option[String] = None) extends AmlsDetails
+import java.time.LocalDate
 
-object OverseasAmlsDetails {
-  implicit val format: OFormat[OverseasAmlsDetails] = Json.format[OverseasAmlsDetails]
+
+case class AmlsEntity(utr: Utr, amlsDetails: UkAmlsDetails, arn: Option[Arn] = None, createdOn: LocalDate, updatedArnOn: Option[LocalDate] = None)
+
+object AmlsEntity {
+  implicit val amlsEntityFormat: OFormat[AmlsEntity] = Json.format[AmlsEntity]
 }

--- a/app/uk/gov/hmrc/agentassurance/models/CreateAmlsRequest.scala
+++ b/app/uk/gov/hmrc/agentassurance/models/CreateAmlsRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,11 @@
 
 package uk.gov.hmrc.agentassurance.models
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.agentmtdidentifiers.model.Utr
 
-case class OverseasAmlsDetails(supervisoryBody: String, membershipNumber: Option[String] = None) extends AmlsDetails
+case class CreateAmlsRequest(utr: Utr, amlsDetails: UkAmlsDetails)
 
-object OverseasAmlsDetails {
-  implicit val format: OFormat[OverseasAmlsDetails] = Json.format[OverseasAmlsDetails]
+object CreateAmlsRequest {
+  implicit val format: Format[CreateAmlsRequest] = Json.format[CreateAmlsRequest]
 }

--- a/app/uk/gov/hmrc/agentassurance/models/UkAmlsDetails.scala
+++ b/app/uk/gov/hmrc/agentassurance/models/UkAmlsDetails.scala
@@ -16,10 +16,21 @@
 
 package uk.gov.hmrc.agentassurance.models
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Format, Json}
 
-case class OverseasAmlsDetails(supervisoryBody: String, membershipNumber: Option[String] = None) extends AmlsDetails
+import java.time.LocalDate
 
-object OverseasAmlsDetails {
-  implicit val format: OFormat[OverseasAmlsDetails] = Json.format[OverseasAmlsDetails]
+case class UkAmlsDetails(supervisoryBody: String,
+                         membershipNumber: Option[String],
+                         amlsSafeId: Option[String] = None,
+                         agentBPRSafeId: Option[String] = None,
+                         appliedOn: Option[LocalDate],
+                         membershipExpiresOn: Option[LocalDate]) extends AmlsDetails {
+  val isPending: Boolean = membershipExpiresOn.isEmpty
+  val isRegistered: Boolean = !isPending
 }
+
+object UkAmlsDetails {
+  implicit val format: Format[UkAmlsDetails] = Json.format[UkAmlsDetails]
+}
+

--- a/app/uk/gov/hmrc/agentassurance/repositories/OverseasAmlsRepository.scala
+++ b/app/uk/gov/hmrc/agentassurance/repositories/OverseasAmlsRepository.scala
@@ -24,6 +24,7 @@ import org.mongodb.scala.model.{IndexModel, IndexOptions}
 import play.api.Logging
 import uk.gov.hmrc.agentassurance.models.AmlsError._
 import uk.gov.hmrc.agentassurance.models._
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 
@@ -33,6 +34,9 @@ import scala.concurrent.{ExecutionContext, Future}
 @ImplementedBy(classOf[OverseasAmlsRepositoryImpl])
 trait OverseasAmlsRepository {
   def create(amlsEntity: OverseasAmlsEntity): Future[Either[AmlsError, Unit]]
+
+  def getOverseasAmlsDetailsByArn(arn: Arn): Future[Option[OverseasAmlsDetails]]
+
 }
 
 @Singleton
@@ -70,4 +74,11 @@ class OverseasAmlsRepositoryImpl @Inject()(mongo: MongoComponent)(implicit ec: E
               Left(AmlsUnexpectedMongoError)
           }
       }
+
+  override def getOverseasAmlsDetailsByArn(arn: Arn): Future[Option[OverseasAmlsDetails]] =
+    collection
+      .find(equal("arn", arn.value))
+      .headOption()
+      .map(_.map(_.amlsDetails))
+
 }

--- a/app/uk/gov/hmrc/agentassurance/services/AmlsDetailsService.scala
+++ b/app/uk/gov/hmrc/agentassurance/services/AmlsDetailsService.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.services
+
+import uk.gov.hmrc.agentassurance.models.AmlsDetails
+import uk.gov.hmrc.agentassurance.repositories.{AmlsRepository, OverseasAmlsRepository}
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class AmlsDetailsService @Inject()(overseasAmlsRepository: OverseasAmlsRepository,
+                                   amlsRepository: AmlsRepository
+                                  )(implicit ec: ExecutionContext) {
+
+  def getAmlsDetailsByArn(arn: Arn): Future[Seq[AmlsDetails]] =
+    Future.sequence(
+      Seq(
+        amlsRepository.getAmlsDetailsByArn(arn),
+        overseasAmlsRepository.getOverseasAmlsDetailsByArn(arn)
+      )
+    ).map(_.flatten)
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -24,6 +24,8 @@ DELETE        /manually-assured/utr/:identifier                                 
 POST          /amls                                                                        @uk.gov.hmrc.agentassurance.controllers.AgentAssuranceController.storeAmlsDetails()
 PUT           /amls/utr/:identifier                                                        @uk.gov.hmrc.agentassurance.controllers.AgentAssuranceController.updateAmlsDetails(identifier: uk.gov.hmrc.agentmtdidentifiers.model.Utr)
 GET           /amls/utr/:identifier                                                        @uk.gov.hmrc.agentassurance.controllers.AgentAssuranceController.getAmlsDetails(identifier: uk.gov.hmrc.agentmtdidentifiers.model.Utr)
-GET           /amls-subscription/:amlsRegistrationNumber                                    @uk.gov.hmrc.agentassurance.controllers.AgentAssuranceController.getAmlsSubscription(amlsRegistrationNumber: String)
+GET           /amls-subscription/:amlsRegistrationNumber                                   @uk.gov.hmrc.agentassurance.controllers.AgentAssuranceController.getAmlsSubscription(amlsRegistrationNumber: String)
 
 POST          /overseas-agents/amls                                                        @uk.gov.hmrc.agentassurance.controllers.AgentAssuranceController.storeOverseasAmlsDetails
+
+GET           /amls/arn/:arn                                                               @uk.gov.hmrc.agentassurance.controllers.GetAmlsDetailsByArnController.getAmlsDetails(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)

--- a/it/uk/gov/hmrc/agentassurance/controllers/AgentAssuranceControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentassurance/controllers/AgentAssuranceControllerISpec.scala
@@ -338,8 +338,8 @@ class AgentAssuranceControllerISpec extends IntegrationSpec
 
     val utr = Utr("7000000002")
     val validApplicationReferenceNumber = "XAML00000123456"
-    val amlsDetails = AmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn = Some(LocalDate.now()))
-    val pendingAmlsDetails = AmlsDetails("supervisory", membershipNumber = Some(validApplicationReferenceNumber), appliedOn = Some(LocalDate.now().minusDays(10)), membershipExpiresOn = None)
+    val amlsDetails = UkAmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn = Some(LocalDate.now()))
+    val pendingAmlsDetails = UkAmlsDetails("supervisory", membershipNumber = Some(validApplicationReferenceNumber), appliedOn = Some(LocalDate.now().minusDays(10)), membershipExpiresOn = None)
     val createAmlsRequest = CreateAmlsRequest(utr, amlsDetails)
     val pendingAmlsDetailsRequest = CreateAmlsRequest(utr, pendingAmlsDetails)
 
@@ -396,7 +396,7 @@ class AgentAssuranceControllerISpec extends IntegrationSpec
       val dbRecord = await(repository.collection.find().toFuture()).head
       dbRecord.utr shouldBe utr
       dbRecord.createdOn shouldBe LocalDate.now()
-      dbRecord.amlsDetails shouldBe AmlsDetails("supervisory", membershipNumber = Some(validApplicationReferenceNumber), appliedOn = Some(LocalDate.now().minusDays(10)), membershipExpiresOn = None)
+      dbRecord.amlsDetails shouldBe UkAmlsDetails("supervisory", membershipNumber = Some(validApplicationReferenceNumber), appliedOn = Some(LocalDate.now().minusDays(10)), membershipExpiresOn = None)
     }
 
     Scenario("stride user should be able to create a registered Amls record without a date (APB-5382)") {
@@ -508,7 +508,7 @@ class AgentAssuranceControllerISpec extends IntegrationSpec
 
     def amlsGetUrl(utr: Utr) = s"http://localhost:$port/agent-assurance/amls/utr/${utr.value}"
 
-    val amlsDetails = AmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn =  Some(LocalDate.now()))
+    val amlsDetails = UkAmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn =  Some(LocalDate.now()))
 
     def callGet(utr: Utr) = Await.result(
       wsClient.url(amlsGetUrl(utr)).withHttpHeaders("Authorization" -> "Bearer XYZ").get(), 10 seconds
@@ -556,7 +556,7 @@ class AgentAssuranceControllerISpec extends IntegrationSpec
 
     def amlsUpdateUrl(utr: Utr) = s"http://localhost:$port/agent-assurance/amls/utr/${utr.value}"
 
-    val amlsDetails = AmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn =  Some(LocalDate.now()))
+    val amlsDetails = UkAmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn =  Some(LocalDate.now()))
 
     def callPut(utr: Utr, arn: Arn) =
       Await.result(

--- a/it/uk/gov/hmrc/agentassurance/controllers/GetAmlsDetailsByArnControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentassurance/controllers/GetAmlsDetailsByArnControllerISpec.scala
@@ -1,0 +1,7 @@
+package uk.gov.hmrc.agentassurance.controllers
+
+class GetAmlsDetailsByArnControllerISpec {
+
+  // TODO - all the tests
+
+}

--- a/it/uk/gov/hmrc/agentassurance/controllers/GetAmlsDetailsByArnControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentassurance/controllers/GetAmlsDetailsByArnControllerISpec.scala
@@ -1,7 +1,105 @@
 package uk.gov.hmrc.agentassurance.controllers
 
-class GetAmlsDetailsByArnControllerISpec {
+import com.google.inject.AbstractModule
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.WSClient
+import uk.gov.hmrc.agentassurance.models.{AmlsEntity, OverseasAmlsDetails, OverseasAmlsEntity, UkAmlsDetails}
+import uk.gov.hmrc.agentassurance.repositories.{AmlsRepository, AmlsRepositoryImpl, OverseasAmlsRepository, OverseasAmlsRepositoryImpl}
+import uk.gov.hmrc.agentassurance.support.{AgentAuthStubs, WireMockSupport}
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Utr}
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.mongo.test.CleanMongoCollectionSupport
 
-  // TODO - all the tests
+import java.time.LocalDate
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+
+class GetAmlsDetailsByArnControllerISpec extends PlaySpec
+  with AgentAuthStubs
+  with GuiceOneServerPerSuite
+  with WireMockSupport
+  with CleanMongoCollectionSupport {
+
+
+  override implicit lazy val app: Application = appBuilder.build()
+
+  protected val ukAmlsRepository: PlayMongoRepository[AmlsEntity] =
+    new AmlsRepositoryImpl(mongoComponent)
+
+  protected val overseasAmlsRepository: PlayMongoRepository[OverseasAmlsEntity] =
+    new OverseasAmlsRepositoryImpl(mongoComponent)
+
+
+  val moduleWithOverrides: AbstractModule = new AbstractModule() {
+    override def configure(): Unit = {
+      bind(classOf[OverseasAmlsRepository]).toInstance(overseasAmlsRepository.asInstanceOf[OverseasAmlsRepositoryImpl])
+      bind(classOf[AmlsRepository]).toInstance(ukAmlsRepository.asInstanceOf[AmlsRepositoryImpl])
+    }
+  }
+
+  protected def appBuilder: GuiceApplicationBuilder =
+    new GuiceApplicationBuilder()
+      .configure("microservice.services.auth.host" -> wireMockHost,
+        "microservice.services.auth.port" -> wireMockPort,
+        "auditing.enabled" -> false,
+        "stride.roles.agent-assurance" -> "maintain_agent_manually_assure")
+      .overrides(moduleWithOverrides)
+
+
+  val arn = Arn("AARN0000002")
+  val url = s"http://localhost:$port/agent-assurance/amls/arn/${arn.value}"
+  override def irAgentReference: String = "IRSA-123"
+
+  val wsClient = app.injector.instanceOf[WSClient]
+  def doRequest() =
+    Await.result(
+      wsClient.url(url)
+        .withHttpHeaders( "Authorization" -> "Bearer XYZ")
+        .get(), 10.seconds
+    )
+
+
+  val testUtr: Utr = Utr("7000000002")
+  val membershipExpiresOnDate: LocalDate = LocalDate.parse("2024-01-12")
+  val testAmlsDetails: UkAmlsDetails = UkAmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn = Some(membershipExpiresOnDate))
+  val testOverseasAmlsDetails: OverseasAmlsDetails = OverseasAmlsDetails("supervisory", membershipNumber = Some("0123456789"))
+  val testOverseasAmlsEntity: OverseasAmlsEntity = OverseasAmlsEntity(arn,testOverseasAmlsDetails)
+
+  val testCreatedDate: LocalDate = LocalDate.parse("2024-01-15")
+  val amlsEntity: AmlsEntity = AmlsEntity(testUtr, testAmlsDetails, Some(arn),testCreatedDate)
+
+
+  "GET /amls/arn/:arn" should {
+    "return 204 when no AMLS records found for the ARN" in {
+      isLoggedInAsStride("stride")
+      val response = doRequest()
+      response.status mustBe 204
+    }
+    "return 200 when UK AMLS records found for the ARN" in {
+      isLoggedInAsStride("stride")
+      ukAmlsRepository.collection.insertOne(amlsEntity).toFuture().futureValue
+      val response = doRequest()
+      response.status mustBe 200
+      response.body[String] mustBe """{"supervisoryBody":"supervisory","membershipNumber":"0123456789","membershipExpiresOn":"2024-01-12"}"""
+    }
+    "return 200 when overseas AMLS records found for the ARN" in {
+      isLoggedInAsStride("stride")
+      overseasAmlsRepository.collection.insertOne(testOverseasAmlsEntity).toFuture().futureValue
+      val response = doRequest()
+      response.status mustBe 200
+      response.body[String] mustBe """{"supervisoryBody":"supervisory","membershipNumber":"0123456789"}"""
+    }
+    "return 500 when overseas and UK AMLS records found for the ARN" in {
+      isLoggedInAsStride("stride")
+      overseasAmlsRepository.collection.insertOne(testOverseasAmlsEntity).toFuture().futureValue
+      ukAmlsRepository.collection.insertOne(amlsEntity).toFuture().futureValue
+      val response = doRequest()
+      response.status mustBe 500
+    }
+  }
 
 }

--- a/test/uk/gov/hmrc/agentassurance/controllers/GetAmlsDetailsByArnControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentassurance/controllers/GetAmlsDetailsByArnControllerSpec.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.controllers
+
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.play.PlaySpec
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.agentassurance.helpers.TestConstants._
+import uk.gov.hmrc.agentassurance.mocks.{MockAmlsDetailsService, MockAppConfig, MockAuthConnector}
+import uk.gov.hmrc.auth.core.AffinityGroup
+import uk.gov.hmrc.auth.core.retrieve.Credentials
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{affinityGroup, allEnrolments, credentials}
+import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
+
+import scala.concurrent.ExecutionContext
+
+class GetAmlsDetailsByArnControllerSpec extends PlaySpec
+  with MockAuthConnector
+  with MockAppConfig
+  with MockAmlsDetailsService
+  with BeforeAndAfterEach {
+
+  val controller = new GetAmlsDetailsByArnController(mockAmlsDetailsService, mockAuthConnector, stubControllerComponents())(mockAppConfig, ExecutionContext.global)
+
+  "getAmlsDetails" should {
+    "return forbidden" when {
+      "not an agent or stride" in {
+        inSequence {
+          mockAuthWithNoRetrievals(allEnrolments and affinityGroup and credentials)(enrolmentsWithoutIrSAAgent and None and None)
+        }
+
+        val response = controller.getAmlsDetails(testArn)(FakeRequest())
+        status(response) mustBe FORBIDDEN
+
+      }
+    }
+
+    "return not found for an agent " when {
+     "there are no records found in the database" in {
+        inSequence {
+          mockAuthWithNoRetrievals(allEnrolments and affinityGroup and credentials)(enrolmentsWithNoIrSAAgent and Some(AffinityGroup.Agent) and Some(Credentials("", "GovernmentGateway")))
+          mockGetAmlsDetailsByArn(testArn)(Nil)
+        }
+
+        val response = controller.getAmlsDetails(testArn)(FakeRequest())
+        status(response) mustBe NOT_FOUND
+
+      }
+    }
+
+    "return not found for a stride user " when {
+     "there are no records found in the database" in {
+        inSequence {
+          mockAuthWithNoRetrievals(allEnrolments and affinityGroup and credentials)(enrolmentsWithStride and None and Some(Credentials("", "PrivilegedApplication")))
+          mockGetAmlsDetailsByArn(testArn)(Nil)
+        }
+
+        val response = controller.getAmlsDetails(testArn)(FakeRequest())
+        status(response) mustBe NOT_FOUND
+
+      }
+    }
+
+    "return OK and AMLS Details for an agent" when {
+     "only a UK AMLS Details record exists in the database" in {
+        inSequence {
+          mockAuthWithNoRetrievals(allEnrolments and affinityGroup and credentials)(enrolmentsWithNoIrSAAgent and Some(AffinityGroup.Agent) and Some(Credentials("", "GovernmentGateway")))
+          mockGetAmlsDetailsByArn(testArn)(Seq(testAmlsDetails))
+        }
+
+        val response = controller.getAmlsDetails(testArn)(FakeRequest())
+        status(response) mustBe OK
+      }
+
+      "only an Overseas AMLS Details record exists in the database" in {
+        inSequence {
+          mockAuthWithNoRetrievals(allEnrolments and affinityGroup and credentials)(enrolmentsWithNoIrSAAgent and Some(AffinityGroup.Agent) and Some(Credentials("", "GovernmentGateway")))
+          mockGetAmlsDetailsByArn(testArn)(Seq(testOverseasAmlsDetails))
+        }
+
+        val response = controller.getAmlsDetails(testArn)(FakeRequest())
+        status(response) mustBe OK
+      }
+    }
+
+    "return OK and AMLS Details for an stride user" when {
+     "only a UK AMLS Details record exists in the database" in {
+        inSequence {
+          mockAuthWithNoRetrievals(allEnrolments and affinityGroup and credentials)(enrolmentsWithStride and None and Some(Credentials("", "PrivilegedApplication")))
+          mockGetAmlsDetailsByArn(testArn)(Seq(testAmlsDetails))
+        }
+
+        val response = controller.getAmlsDetails(testArn)(FakeRequest())
+        status(response) mustBe OK
+      }
+
+      "only an Overseas AMLS Details record exists in the database" in {
+        inSequence {
+          mockAuthWithNoRetrievals(allEnrolments and affinityGroup and credentials)(enrolmentsWithStride and None and Some(Credentials("", "PrivilegedApplication")))
+          mockGetAmlsDetailsByArn(testArn)(Seq(testOverseasAmlsDetails))
+        }
+
+        val response = controller.getAmlsDetails(testArn)(FakeRequest())
+        status(response) mustBe OK
+      }
+    }
+
+    /*
+    TODO - add test for exception case using mockGetAmlsDetailsByArn(testArn)(Seq(testOverseasAmlsDetails, testAmlsDetails))
+    TODO - check Json in OK responses equals Json.toJson(AmlsDetails) or Json.toJson(OverseasAmlsDetails)
+     */
+  }
+
+}

--- a/test/uk/gov/hmrc/agentassurance/helpers/TestConstants.scala
+++ b/test/uk/gov/hmrc/agentassurance/helpers/TestConstants.scala
@@ -48,7 +48,8 @@ object TestConstants {
   val testValidApplicationReferenceNumber = "XAML00000123456"
   val testArn = Arn("ARN123")
 
-  val testAmlsDetails = UkAmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn = Some(LocalDate.now()))
+  val membershipExpiresOnDate = LocalDate.parse("2024-01-12")
+  val testAmlsDetails = UkAmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn = Some(membershipExpiresOnDate))
   val testOverseasAmlsDetails = OverseasAmlsDetails("supervisory", membershipNumber = Some("0123456789"))
 
 }

--- a/test/uk/gov/hmrc/agentassurance/helpers/TestConstants.scala
+++ b/test/uk/gov/hmrc/agentassurance/helpers/TestConstants.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.helpers
+
+import uk.gov.hmrc.agentassurance.models.{OverseasAmlsDetails, UkAmlsDetails}
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Utr}
+import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier, Enrolments}
+import uk.gov.hmrc.domain.{Nino, SaAgentReference}
+
+import java.time.LocalDate
+
+object TestConstants {
+
+  val irSaAgentEnrolment: Set[Enrolment] = Set(
+    Enrolment("IR-SA-AGENT", Seq(EnrolmentIdentifier("IRAgentReference", "IRSA-123")), state = "activated", delegatedAuthRule = None)
+  )
+
+  val hmrcAsAgentEnrolment: Set[Enrolment] = Set(
+    Enrolment("HMRC-AS-AGENT", Seq(EnrolmentIdentifier("AgentReferenceNumber", "ARN123")), state = "activated", delegatedAuthRule = None)
+  )
+
+  val strideEnrolment: Set[Enrolment] = Set(
+    Enrolment("maintain_agent_manually_assure", Seq.empty, state = "activated", delegatedAuthRule = None)
+  )
+
+  val enrolmentsWithIrSAAgent = Enrolments(irSaAgentEnrolment)
+  val enrolmentsWithNoIrSAAgent = Enrolments(hmrcAsAgentEnrolment)
+  val enrolmentsWithoutIrSAAgent = Enrolments(Set.empty)
+  val enrolmentsWithStride = Enrolments(strideEnrolment)
+
+  val testNino = Nino("AA000000A")
+  val testUtr = Utr("7000000002")
+  val testSaAgentReference = SaAgentReference("IRSA-123")
+  val testValidApplicationReferenceNumber = "XAML00000123456"
+  val testArn = Arn("ARN123")
+
+  val testAmlsDetails = UkAmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn = Some(LocalDate.now()))
+  val testOverseasAmlsDetails = OverseasAmlsDetails("supervisory", membershipNumber = Some("0123456789"))
+
+}

--- a/test/uk/gov/hmrc/agentassurance/mocks/MockAmlsDetailsService.scala
+++ b/test/uk/gov/hmrc/agentassurance/mocks/MockAmlsDetailsService.scala
@@ -14,8 +14,22 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentassurance.models
+package uk.gov.hmrc.agentassurance.mocks
 
-trait AmlsDetails {
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.agentassurance.models.AmlsDetails
+import uk.gov.hmrc.agentassurance.services.AmlsDetailsService
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
+
+import scala.concurrent.Future
+
+trait MockAmlsDetailsService extends MockFactory {
+
+  val mockAmlsDetailsService = mock[AmlsDetailsService]
+
+  def mockGetAmlsDetailsByArn(arn: Arn)(response: Seq[AmlsDetails]) =
+    (mockAmlsDetailsService.getAmlsDetailsByArn(_: Arn))
+      .expects(arn)
+      .returning(Future.successful(response))
 
 }

--- a/test/uk/gov/hmrc/agentassurance/mocks/MockAmlsRepository.scala
+++ b/test/uk/gov/hmrc/agentassurance/mocks/MockAmlsRepository.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.mocks
+
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.agentassurance.models.{AmlsError, CreateAmlsRequest, UkAmlsDetails}
+import uk.gov.hmrc.agentassurance.repositories.AmlsRepository
+import uk.gov.hmrc.agentassurance.util.toFuture
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Utr}
+
+trait MockAmlsRepository extends MockFactory {
+
+  val mockAmlsRepository = mock[AmlsRepository]
+
+  def mockCreateAmls(createAmlsRequest: CreateAmlsRequest)(response: Either[AmlsError, Unit]) = {
+    (mockAmlsRepository.createOrUpdate(_: CreateAmlsRequest))
+      .expects(createAmlsRequest)
+      .returning(toFuture(response))
+  }
+
+  def mockUpdateAmls(utr: Utr, arn: Arn)(response: Either[AmlsError, UkAmlsDetails]) = {
+    (mockAmlsRepository.updateArn(_: Utr, _: Arn))
+      .expects(utr, arn)
+      .returning(toFuture(response))
+  }
+
+  def mockGetAmls(utr: Utr)(response: Option[UkAmlsDetails]) = {
+    (mockAmlsRepository.getAmlDetails(_: Utr))
+      .expects(utr)
+      .returning(toFuture(response))
+  }
+ def mockGetAmlsDetailsByArn(arn: Arn)(response: Option[UkAmlsDetails]) = {
+    (mockAmlsRepository.getAmlsDetailsByArn(_: Arn))
+      .expects(arn)
+      .returning(toFuture(response))
+  }
+
+}

--- a/test/uk/gov/hmrc/agentassurance/mocks/MockAppConfig.scala
+++ b/test/uk/gov/hmrc/agentassurance/mocks/MockAppConfig.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.mocks
+
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.agentassurance.config.AppConfig
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+trait MockAppConfig extends MockFactory {
+
+  val mockServiceConfig: ServicesConfig = mock[ServicesConfig]
+
+  (mockServiceConfig.getInt(_: String)).expects(*).atLeastOnce().returning(1)
+  (mockServiceConfig.baseUrl(_: String)).expects(*).atLeastOnce().returning("some-url")
+  (mockServiceConfig.getConfString(_: String, _: String)).expects(*, *).atLeastOnce().returning("some-string")
+  (mockServiceConfig.getString(_: String)).expects("stride.roles.agent-assurance").atLeastOnce().returning("maintain_agent_manually_assure")
+
+  val mockAppConfig: AppConfig = new AppConfig(mockServiceConfig)
+}

--- a/test/uk/gov/hmrc/agentassurance/mocks/MockAuthConnector.scala
+++ b/test/uk/gov/hmrc/agentassurance/mocks/MockAuthConnector.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.mocks
+
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
+import uk.gov.hmrc.auth.core.authorise.{EmptyPredicate, Predicate}
+import uk.gov.hmrc.auth.core.retrieve.{EmptyRetrieval, Retrieval}
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
+import uk.gov.hmrc.auth.core.{AffinityGroup, AuthConnector, AuthProviders, Enrolments}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockAuthConnector extends MockFactory {
+
+  val mockAuthConnector = mock[AuthConnector]
+
+  def mockAuth()(response: Either[String, Enrolments]) = {
+    (mockAuthConnector.authorise(_: Predicate, _: Retrieval[Enrolments])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(AuthProviders(GovernmentGateway), Retrievals.allEnrolments, *, *)
+      .returning(response.fold[Future[Enrolments]](e => Future.failed(new Exception(e)), r => Future.successful(r)))
+  }
+
+  def mockAuthWithNoRetrievals[A](retrieval: Retrieval[A])(result: A) = {
+    (mockAuthConnector.authorise[A](_: Predicate, _: Retrieval[A])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(EmptyPredicate, retrieval, *, *)
+      .returning(Future.successful(result))
+  }
+
+  def mockAgentAuth()(response: Either[String, Unit]) = {
+    (mockAuthConnector.authorise(_: Predicate, _: EmptyRetrieval.type)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(AuthProviders(GovernmentGateway) and AffinityGroup.Agent, EmptyRetrieval, *, *)
+      .returning(response.fold[Future[Unit]](e => Future.failed(new Exception(e)), r => Future.successful(r)))
+  }
+
+
+}

--- a/test/uk/gov/hmrc/agentassurance/mocks/MockDesConnector.scala
+++ b/test/uk/gov/hmrc/agentassurance/mocks/MockDesConnector.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.mocks
+
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.agentassurance.connectors.DesConnector
+import uk.gov.hmrc.agentassurance.util.toFuture
+import uk.gov.hmrc.domain.{SaAgentReference, TaxIdentifier}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockDesConnector extends MockFactory {
+
+  val mockDesConnector = mock[DesConnector]
+
+  def mockDes(ti: TaxIdentifier)(response: Either[String, Option[Seq[SaAgentReference]]]) = {
+    (mockDesConnector.getActiveCesaAgentRelationships(_: TaxIdentifier)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(ti, *, *)
+      .returning(response.fold[Future[Option[Seq[SaAgentReference]]]](e => Future.failed(new Exception(e)), r => toFuture(r)))
+  }
+
+
+}

--- a/test/uk/gov/hmrc/agentassurance/mocks/MockEnrolmentStoreProxyConnector.scala
+++ b/test/uk/gov/hmrc/agentassurance/mocks/MockEnrolmentStoreProxyConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentassurance.models
+package uk.gov.hmrc.agentassurance.mocks
 
-import play.api.libs.json.{Json, OFormat}
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.agentassurance.connectors.EnrolmentStoreProxyConnector
 
-case class OverseasAmlsDetails(supervisoryBody: String, membershipNumber: Option[String] = None) extends AmlsDetails
+trait MockEnrolmentStoreProxyConnector extends MockFactory {
 
-object OverseasAmlsDetails {
-  implicit val format: OFormat[OverseasAmlsDetails] = Json.format[OverseasAmlsDetails]
+  val mockEspConnector = mock[EnrolmentStoreProxyConnector]
+
 }

--- a/test/uk/gov/hmrc/agentassurance/mocks/MockOverseasAmlsRepository.scala
+++ b/test/uk/gov/hmrc/agentassurance/mocks/MockOverseasAmlsRepository.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.mocks
+
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.agentassurance.models.{AmlsError, OverseasAmlsDetails, OverseasAmlsEntity}
+import uk.gov.hmrc.agentassurance.repositories.OverseasAmlsRepository
+import uk.gov.hmrc.agentassurance.util.toFuture
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
+
+trait MockOverseasAmlsRepository extends MockFactory {
+
+  val mockOverseasAmlsRepository = mock[OverseasAmlsRepository]
+
+  def mockCreateOverseasAmls(amlsEntity: OverseasAmlsEntity)(response: Either[AmlsError, Unit]) = {
+    (mockOverseasAmlsRepository.create(_: OverseasAmlsEntity))
+      .expects(amlsEntity)
+      .returning(toFuture(response))
+  }
+
+  def mockGetOverseasAmlsDetailsByArn(arn: Arn)(response: Option[OverseasAmlsDetails]) = {
+    (mockOverseasAmlsRepository.getOverseasAmlsDetailsByArn(_: Arn))
+      .expects(arn)
+      .returning(toFuture(response))
+  }
+
+
+}

--- a/test/uk/gov/hmrc/agentassurance/services/AmlsDetailsServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentassurance/services/AmlsDetailsServiceSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.services
+
+import org.scalatestplus.play.PlaySpec
+import play.api.test.Helpers._
+import uk.gov.hmrc.agentassurance.helpers.TestConstants.{testAmlsDetails, testArn, testOverseasAmlsDetails}
+import uk.gov.hmrc.agentassurance.mocks.{MockAmlsRepository, MockOverseasAmlsRepository}
+
+import scala.concurrent.ExecutionContext
+
+class AmlsDetailsServiceSpec extends PlaySpec with MockAmlsRepository with MockOverseasAmlsRepository {
+
+  val service = new AmlsDetailsService(mockOverseasAmlsRepository, mockAmlsRepository)(ExecutionContext.global)
+
+  "getAmlsDetailsByArn" should {
+    "return Future(Seq(UkAmlsDetails(_,_,_,_,_,_)))" when {
+      "only UK AMLS Details are available" in {
+        mockGetAmlsDetailsByArn(testArn)(Some(testAmlsDetails))
+        mockGetOverseasAmlsDetailsByArn(testArn)(None)
+
+        val result = await(service.getAmlsDetailsByArn(testArn))
+
+        result mustBe Seq(testAmlsDetails)
+
+      }
+    }
+
+    "return Future(Seq(OverseasAmlsDetails(_,_)))" when {
+      "only Overseas AMLS Details are available" in {
+        mockGetAmlsDetailsByArn(testArn)(None)
+        mockGetOverseasAmlsDetailsByArn(testArn)(Some(testOverseasAmlsDetails))
+
+        val result = await(service.getAmlsDetailsByArn(testArn))
+
+        result mustBe Seq(testOverseasAmlsDetails)
+
+      }
+    }
+
+    "return Future(Seq(UkAmlsDetails(_,_,_,_,_,_)), OverseasAmlsDetails(_,_)))" when {
+      "when both are available (technically should never happen)" in {
+        mockGetAmlsDetailsByArn(testArn)(Some(testAmlsDetails))
+        mockGetOverseasAmlsDetailsByArn(testArn)(Some(testOverseasAmlsDetails))
+
+        val result = await(service.getAmlsDetailsByArn(testArn))
+
+        result mustBe Seq(testAmlsDetails, testOverseasAmlsDetails)
+      }
+    }
+
+    "return Future(Seq())" when {
+      "when none are available" in {
+        mockGetAmlsDetailsByArn(testArn)(None)
+        mockGetOverseasAmlsDetailsByArn(testArn)(None)
+
+        val result = await(service.getAmlsDetailsByArn(testArn))
+
+        result mustBe Seq.empty
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This endpoint is capable of returning UK and overseas AMLS records. This is required for the changes being made in the dashboard to display current AMLS details for the agent, who may have subscribed by either the overseas or the UK route.
Test coverage is 100%, achieved on unit tests. Integration tests additionally integrate with the UK and overseas AMLS Mongo collections.