### PR TITLE
Apb 7797 [CS, RM] add logic if no record to determine if UK or Overseas

### DIFF
--- a/app/uk/gov/hmrc/agentassurance/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentassurance/config/AppConfig.scala
@@ -29,17 +29,18 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig) {
 
   private def baseUrl(key: String) = servicesConfig.baseUrl(key)
 
-  val authBaseUrl = baseUrl("auth")
-  val desBaseUrl = baseUrl("des")
-  val esProxyUrl = baseUrl("enrolment-store-proxy")
+  val authBaseUrl: String = baseUrl("auth")
+  val desBaseUrl: String = baseUrl("des")
+  val acaBaseUrl: String = baseUrl("agent-client-authorisation")
+  val esProxyUrl: String = baseUrl("enrolment-store-proxy")
 
-  val minimumIRPAYEClients = servicesConfig.getInt("minimumIRPAYEClients")
-  val minimumIRSAClients = servicesConfig.getInt("minimumIRSAClients")
-  val minimumVatDecOrgClients = servicesConfig.getInt("minimumVatDecOrgClients")
-  val minimumIRCTClients = servicesConfig.getInt("minimumIRCTClients")
+  val minimumIRPAYEClients: Int = servicesConfig.getInt("minimumIRPAYEClients")
+  val minimumIRSAClients: Int = servicesConfig.getInt("minimumIRSAClients")
+  val minimumVatDecOrgClients: Int = servicesConfig.getInt("minimumVatDecOrgClients")
+  val minimumIRCTClients: Int = servicesConfig.getInt("minimumIRCTClients")
 
-  val manuallyAssuredStrideRole = servicesConfig.getString("stride.roles.agent-assurance")
+  val manuallyAssuredStrideRole: String = servicesConfig.getString("stride.roles.agent-assurance")
 
-  val desEnv = getConf("des.environment")
-  val desAuthToken = getConf("des.authorization-token")
+  val desEnv: String = getConf("des.environment")
+  val desAuthToken: String = getConf("des.authorization-token")
 }

--- a/app/uk/gov/hmrc/agentassurance/connectors/AgentClientAuthConnector.scala
+++ b/app/uk/gov/hmrc/agentassurance/connectors/AgentClientAuthConnector.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.agentassurance.connectors
 
 import com.codahale.metrics.MetricRegistry
+import com.google.inject.ImplementedBy
 import com.kenshoo.play.metrics.Metrics
 import play.api.http.Status.{NO_CONTENT, OK}
 import play.api.i18n.Lang.logger
@@ -30,14 +31,19 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse, Int
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
+@ImplementedBy(classOf[AgentClientAuthConnectorImpl])
+trait AgentClientAuthConnector {
+  def getAgencyDetails()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[AgencyDetails]]
+}
+
 @Singleton
-class AgentClientAuthConnector @Inject()(http: HttpClient, metrics: Metrics)
+class AgentClientAuthConnectorImpl @Inject()(http: HttpClient, metrics: Metrics)
                                         (implicit appConfig: AppConfig) extends HttpAPIMonitor {
 
   override val kenshooRegistry: MetricRegistry = metrics.defaultRegistry
 
   def getAgencyDetails()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[AgencyDetails]] =
-    monitor("ConsumerAPI-Get-AgencyDetails-GET") {
+    monitor("ConsumerAPI-AgentClientAuthorisation-AgencyDetails-GET") {
       http.GET[Option[AgencyDetails]](s"${appConfig.acaBaseUrl}/agent-client-authorisation/agent/agency-details")(
         AgentClientAuthHttpReads,
         hc,

--- a/app/uk/gov/hmrc/agentassurance/connectors/AgentClientAuthConnector.scala
+++ b/app/uk/gov/hmrc/agentassurance/connectors/AgentClientAuthConnector.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.connectors
+
+import com.codahale.metrics.MetricRegistry
+import com.kenshoo.play.metrics.Metrics
+import play.api.http.Status.{NO_CONTENT, OK}
+import play.api.i18n.Lang.logger
+import play.api.libs.json.{JsError, JsSuccess, Json}
+import uk.gov.hmrc.agent.kenshoo.monitoring.HttpAPIMonitor
+import uk.gov.hmrc.agentassurance.config.AppConfig
+import uk.gov.hmrc.agentassurance.models.AgencyDetails
+//import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, InternalServerException}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class AgentClientAuthConnector @Inject()(http: HttpClient, metrics: Metrics)(implicit appConfig: AppConfig) extends HttpAPIMonitor {
+  val baseUrl: String = appConfig.acaBaseUrl
+  override val kenshooRegistry: MetricRegistry = metrics.defaultRegistry
+
+  def getAgencyDetails()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[AgencyDetails]] =
+    monitor("ConsumerAPI-Get-AgencyDetails-GET") {
+      http
+        .GET[HttpResponse](s"${appConfig.acaBaseUrl}/agent-client-authorisation/agent/agency-details")
+        .map(response =>
+          response.status match {
+            case OK => Json.parse(response.body).validate[AgencyDetails] match {
+              case JsSuccess(value,_) => Some(value)
+              case JsError(e) => throw new InternalServerException(e.mkString)
+            }
+            case NO_CONTENT => None
+            case s => logger.error(s"unexpected response $s when getting agency details")
+              None
+          }
+        )
+    }
+
+}

--- a/app/uk/gov/hmrc/agentassurance/connectors/EnrolmentStoreProxyConnector.scala
+++ b/app/uk/gov/hmrc/agentassurance/connectors/EnrolmentStoreProxyConnector.scala
@@ -19,14 +19,13 @@ package uk.gov.hmrc.agentassurance.connectors
 import com.codahale.metrics.MetricRegistry
 import com.google.inject.ImplementedBy
 import com.kenshoo.play.metrics.Metrics
-import javax.inject.{Inject, Singleton}
-import play.api.libs.json.{Format, JsValue}
 import play.api.libs.json.Json.{format, fromJson}
+import play.api.libs.json.{Format, JsValue}
 import uk.gov.hmrc.agent.kenshoo.monitoring.HttpAPIMonitor
 import uk.gov.hmrc.agentassurance.config.AppConfig
-import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
-import uk.gov.hmrc.http.HttpClient
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 

--- a/app/uk/gov/hmrc/agentassurance/controllers/MaaController.scala
+++ b/app/uk/gov/hmrc/agentassurance/controllers/MaaController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.agentassurance.controllers
 
-import javax.inject.{Inject, Singleton}
 import play.api.libs.json.Json
 import play.api.mvc.ControllerComponents
 import uk.gov.hmrc.agentassurance.auth.AuthActions
@@ -29,6 +28,7 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.BadRequestException
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton

--- a/app/uk/gov/hmrc/agentassurance/controllers/R2dwController.scala
+++ b/app/uk/gov/hmrc/agentassurance/controllers/R2dwController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.agentassurance.controllers
 
-import javax.inject.{Inject, Singleton}
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.agentassurance.auth.AuthActions
@@ -29,6 +28,7 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.BadRequestException
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton

--- a/app/uk/gov/hmrc/agentassurance/controllers/testOnly/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/agentassurance/controllers/testOnly/TestOnlyController.scala
@@ -16,9 +16,10 @@
 
 package uk.gov.hmrc.agentassurance.controllers.testOnly
 
-import javax.inject.{Inject, Singleton}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.agentassurance.controllers.AgentAssuranceController
+
+import javax.inject.{Inject, Singleton}
 
 @Singleton
 class TestOnlyController @Inject()(ctrl: AgentAssuranceController) {

--- a/app/uk/gov/hmrc/agentassurance/models/AgencyDetails.scala
+++ b/app/uk/gov/hmrc/agentassurance/models/AgencyDetails.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class AgencyDetails(
+                          agencyName: Option[String],
+                          agencyEmail: Option[String],
+                          agencyTelephone: Option[String],
+                          agencyAddress: Option[BusinessAddress]
+                        )
+object AgencyDetails {
+  implicit val agencyDetailsFormat: OFormat[AgencyDetails] = Json.format[AgencyDetails]
+}
+
+case class BusinessAddress(
+                            addressLine1: String,
+                            addressLine2: Option[String],
+                            addressLine3: Option[String] = None,
+                            addressLine4: Option[String] = None,
+                            postalCode: Option[String],
+                            countryCode: String
+                          )
+
+object BusinessAddress {
+  implicit val format: OFormat[BusinessAddress] = Json.format
+}

--- a/app/uk/gov/hmrc/agentassurance/models/pagination/PaginationLinks.scala
+++ b/app/uk/gov/hmrc/agentassurance/models/pagination/PaginationLinks.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.agentassurance.models.pagination
 
-import java.net.URLEncoder
-
 import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.agentassurance.binders.PaginationParameters
+
+import java.net.URLEncoder
 
 case class PaginationLinks(
                             self: LinkHref,

--- a/app/uk/gov/hmrc/agentassurance/services/AgencyDetailsService.scala
+++ b/app/uk/gov/hmrc/agentassurance/services/AgencyDetailsService.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentassurance.services
+
+import play.api.Logging
+import uk.gov.hmrc.agentassurance.connectors.AgentClientAuthConnector
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class AgencyDetailsService @Inject()(acaConnector: AgentClientAuthConnector
+                                  )(implicit ec: ExecutionContext, hc: HeaderCarrier) extends Logging {
+
+  def isUkAddress(): Future[Boolean] = {
+    for {
+      optAgencyDetails <- acaConnector.getAgencyDetails()
+      optAddress = optAgencyDetails.flatMap(_.agencyAddress)
+      countryCodeIsUk = optAddress.exists(_.countryCode == "GB")
+    } yield countryCodeIsUk
+  }
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -64,6 +64,12 @@ microservice {
         host = localhost
         port = 7775
       }
+
+      agent-client-authorisation {
+        host=localhost
+        port=9432
+      }
+
     }
 }
 

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>[%level] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.google.inject" level="OFF"/>
+    <logger name="org.asynchttpclient.netty" level="OFF"/>
+    <logger name="io.netty.buffer" level="OFF"/>
+    <logger name="play.core.netty" level="OFF"/>
+
+    <root level="DEBUG">
+        <!-- We send DEBUG logs to an ERROR-filtering appender rather than setting log level to ERROR directly
+        so that all the logging statements are exercised during tests -->
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/it/uk/gov/hmrc/agentassurance/connectors/AgentClientAuthConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentassurance/connectors/AgentClientAuthConnectorISpec.scala
@@ -77,7 +77,7 @@ class AgentClientAuthConnectorISpec extends UnitSpec with GuiceOneAppPerSuite wi
     "throw an exception if JSON does not parse" in {
       getAgentDetails(Json.obj(), OK)
 
-      val exception: InternalServerException = intercept[InternalServerException] { await(acaConnector.getAgencyDetails()) }
+      val exception: InternalServerException = intercept[InternalServerException]{ await(acaConnector.getAgencyDetails()) }
       exception.message shouldBe ""
     }
 

--- a/it/uk/gov/hmrc/agentassurance/connectors/AgentClientAuthConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentassurance/connectors/AgentClientAuthConnectorISpec.scala
@@ -21,7 +21,7 @@ class AgentClientAuthConnectorISpec extends UnitSpec with GuiceOneAppPerSuite wi
 
   implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
-  val acaConnector = new AgentClientAuthConnector(app.injector.instanceOf[HttpClient], app.injector.instanceOf[Metrics])
+  val acaConnector = new AgentClientAuthConnectorImpl(app.injector.instanceOf[HttpClient], app.injector.instanceOf[Metrics])
 
   protected def appBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
@@ -39,7 +39,7 @@ class AgentClientAuthConnectorISpec extends UnitSpec with GuiceOneAppPerSuite wi
         "auditing.consumer.baseUri.host" -> wireMockHost,
         "auditing.consumer.baseUri.port" -> wireMockPort
       )
-      .bindings(bind[AgentClientAuthConnector].toInstance(acaConnector))
+      .bindings(bind[AgentClientAuthConnectorImpl].toInstance(acaConnector))
 
   private implicit val hc: HeaderCarrier = HeaderCarrier()
   private implicit val ec: ExecutionContext = ExecutionContext.global
@@ -75,10 +75,9 @@ class AgentClientAuthConnectorISpec extends UnitSpec with GuiceOneAppPerSuite wi
     }
 
     "throw an exception if JSON does not parse" in {
-      getAgentDetails(Json.obj(), OK)
+      getAgentDetails(Json.obj("agencyName" -> 1), OK) //not empty because all AgencyDetails are optional
 
-      val exception: InternalServerException = intercept[InternalServerException]{ await(acaConnector.getAgencyDetails()) }
-      exception.message shouldBe ""
+      intercept[InternalServerException]{ await(acaConnector.getAgencyDetails()) }
     }
 
 

--- a/it/uk/gov/hmrc/agentassurance/connectors/AgentClientAuthConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentassurance/connectors/AgentClientAuthConnectorISpec.scala
@@ -1,0 +1,87 @@
+package uk.gov.hmrc.agentassurance.connectors
+
+import com.kenshoo.play.metrics.Metrics
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import uk.gov.hmrc.agentassurance.config.AppConfig
+import uk.gov.hmrc.agentassurance.models.{AgencyDetails, BusinessAddress}
+import uk.gov.hmrc.agentassurance.stubs.AgentClientAuthorisationStub
+import uk.gov.hmrc.agentassurance.support.{UnitSpec, WireMockSupport}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, InternalServerException}
+
+import scala.concurrent.ExecutionContext
+
+class AgentClientAuthConnectorISpec extends UnitSpec with GuiceOneAppPerSuite with WireMockSupport with AgentClientAuthorisationStub {
+
+  override implicit lazy val app: Application = appBuilder.build()
+
+  implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+
+  val acaConnector = new AgentClientAuthConnector(app.injector.instanceOf[HttpClient], app.injector.instanceOf[Metrics])
+
+  protected def appBuilder: GuiceApplicationBuilder =
+    new GuiceApplicationBuilder()
+      .configure(
+        "microservice.services.auth.host" -> wireMockHost,
+        "microservice.services.auth.port" -> wireMockPort,
+        "microservice.services.des.host" -> wireMockHost,
+        "microservice.services.des.port" -> wireMockPort,
+        "microservice.services.agent-client-authorisation.host" -> wireMockHost,
+        "microservice.services.agent-client-authorisation.port" -> wireMockPort,
+        "microservice.services.des.environment" -> "test",
+        "microservice.services.des.authorization-token" -> "secret",
+        "microservice.services.enrolment-store-proxy.host" -> wireMockHost,
+        "microservice.services.enrolment-store-proxy.port" -> wireMockPort,
+        "auditing.consumer.baseUri.host" -> wireMockHost,
+        "auditing.consumer.baseUri.port" -> wireMockPort
+      )
+      .bindings(bind[AgentClientAuthConnector].toInstance(acaConnector))
+
+  private implicit val hc: HeaderCarrier = HeaderCarrier()
+  private implicit val ec: ExecutionContext = ExecutionContext.global
+
+  "getAgencyDetails" should {
+    "return agency details for a given agent" in {
+      val agentDetails = AgencyDetails(
+        Some("My Agency"),
+        Some("abc@abc.com"),
+        Some("07345678901"),
+        Some(BusinessAddress(
+          "25 Any Street",
+          Some("Central Grange"),
+          Some("Telford"),
+          None,
+          Some("TF4 3TR"),
+          "GB"))
+      )
+
+      getAgentDetails(Json.toJson(agentDetails), OK)
+
+      await(acaConnector.getAgencyDetails()) shouldBe Some(agentDetails)
+    }
+
+    "return None when response is 204" in {
+      getAgentDetails(Json.obj(), NO_CONTENT)
+      await(acaConnector.getAgencyDetails()) shouldBe None
+    }
+
+    "return None with any other status" in {
+      getAgentDetails(Json.obj(), INTERNAL_SERVER_ERROR)
+      await(acaConnector.getAgencyDetails()) shouldBe None
+    }
+
+    "throw an exception if JSON does not parse" in {
+      getAgentDetails(Json.obj(), OK)
+
+      val exception: InternalServerException = intercept[InternalServerException] { await(acaConnector.getAgencyDetails()) }
+      exception.message shouldBe ""
+    }
+
+
+  }
+
+}

--- a/it/uk/gov/hmrc/agentassurance/stubs/AgentClientAuthorisationStub.scala
+++ b/it/uk/gov/hmrc/agentassurance/stubs/AgentClientAuthorisationStub.scala
@@ -1,0 +1,17 @@
+package uk.gov.hmrc.agentassurance.stubs
+
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, stubFor, urlEqualTo}
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.libs.json.JsValue
+
+trait AgentClientAuthorisationStub {
+
+  def getAgentDetails(responseBody: JsValue, status: Int): StubMapping =
+    stubFor(get(urlEqualTo("/agent-client-authorisation/agent/agency-details"))
+      .willReturn(
+        aResponse()
+          .withStatus(status)
+          .withBody(responseBody.toString)
+      ))
+
+}

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -1,13 +1,28 @@
+import sbt.Def
 
 object CodeCoverageSettings {
+
+  private val excludedPackages: Seq[String] = Seq(
+    "uk.gov.hmrc.BuildInfo",
+    ".*Routes.*",
+    ".*RoutesPrefix.*",
+    ".*Filters?",
+    "MicroserviceAuditConnector",
+    "Module",
+    "GraphiteStartUp",
+    "ErrorHandler",
+    ".*.Reverse[^.]*",
+    "uk.gov.hmrc.agentassurance.controllers.testOnly",
+    "testOnly.*",
+    "testOnlyDoNotUseInAppConf.*"
+  )
 
   lazy val scoverageSettings = {
     import scoverage.ScoverageKeys
     Seq(
-      // Semicolon-separated list of regexs matching classes to exclude
-      ScoverageKeys.coverageExcludedPackages := """uk\.gov\.hmrc\.BuildInfo;.*\.Routes;.*\.RoutesPrefix;.*Filters?;MicroserviceAuditConnector;Module;GraphiteStartUp;ErrorHandler;.*\.Reverse[^.]*""",
+      ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(";"),
       ScoverageKeys.coverageMinimumStmtTotal := 80.00,
-      // ScoverageKeys.coverageMinimumStmtPerFile := 80.00,
+      //ScoverageKeys.coverageMinimumStmtPerFile := 80.00,
       ScoverageKeys.coverageFailOnMinimum := false,
       ScoverageKeys.coverageHighlighting := true
     )

--- a/test/uk/gov/hmrc/agentassurance/helpers/TestConstants.scala
+++ b/test/uk/gov/hmrc/agentassurance/helpers/TestConstants.scala
@@ -45,20 +45,25 @@ object TestConstants {
   val testNino: Nino = Nino("AA000000A")
   val testUtr: Utr = Utr("7000000002")
   val testSaAgentReference: SaAgentReference = SaAgentReference("IRSA-123")
-  val testValidApplicationReferenceNumber: String = "XAML00000123456"
+  val testValidApplicationReferenceNumber = "XAML00000123456"
   val testArn: Arn = Arn("ARN123")
-  val today = LocalDate.now
+  val today: LocalDate = LocalDate.now
 
 
-  val membershipExpiresOnDate = LocalDate.parse("2024-01-12")
-  val testAmlsDetails = UkAmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn = Some(membershipExpiresOnDate))
-  val testUKAmlsEntity = UkAmlsEntity(utr = Some(testUtr), amlsDetails = testAmlsDetails, arn = Some(testArn),
+  val membershipExpiresOnDate: LocalDate = LocalDate.parse("2024-01-12")
+  val testAmlsDetails: UkAmlsDetails = UkAmlsDetails("supervisory", membershipNumber = Some("0123456789"), appliedOn = None, membershipExpiresOn = Some(membershipExpiresOnDate))
+  val testUKAmlsEntity: UkAmlsEntity = UkAmlsEntity(utr = Some(testUtr), amlsDetails = testAmlsDetails, arn = Some(testArn),
     createdOn = today, updatedArnOn = None, amlsSource = AmlsSource.Subscription)
 
   val testHmrcAmlsDetails: UkAmlsDetails = UkAmlsDetails("HM Revenue and Customs (HMRC)", membershipNumber = Some(testValidApplicationReferenceNumber), appliedOn = None, membershipExpiresOn = Some(LocalDate.now()))
   val testHmrcAmlsDetailsNoMembershipNumber: UkAmlsDetails = UkAmlsDetails("HM Revenue and Customs (HMRC)", membershipNumber = None, appliedOn = None, membershipExpiresOn = Some(LocalDate.now()))
   val testOverseasAmlsDetails: OverseasAmlsDetails = OverseasAmlsDetails("supervisory", membershipNumber = Some("0123456789"))
-  val testOverseasAmlsEntity = OverseasAmlsEntity(testArn, testOverseasAmlsDetails, None)
-  val testUKAmlsRequest = AmlsRequest(ukRecord = true, Some(testUtr), "supervisory", "0123456789", Some(membershipExpiresOnDate))
-  val testOverseasAmlsRequest = AmlsRequest(ukRecord = false, None, "supervisory", "0123456789", Some(membershipExpiresOnDate))
+  val testOverseasAmlsEntity: OverseasAmlsEntity = OverseasAmlsEntity(testArn, testOverseasAmlsDetails, None)
+  val testUKAmlsRequest: AmlsRequest = AmlsRequest(ukRecord = true, Some(testUtr), "supervisory", "0123456789", Some(membershipExpiresOnDate))
+  val testOverseasAmlsRequest: AmlsRequest = AmlsRequest(ukRecord = false, None, "supervisory", "0123456789", Some(membershipExpiresOnDate))
+
+  val agencyDetailsUk: AgencyDetails = AgencyDetails(None, None, None,
+    Some(BusinessAddress("line1", None, None, None, None, "GB")))
+  val agencyDetailsOverseas: AgencyDetails = AgencyDetails(None, None, None,
+    Some(BusinessAddress("line1", None, None, None, None, "US")))
 }

--- a/test/uk/gov/hmrc/agentassurance/mocks/MockAgentClientAuthConnector.scala
+++ b/test/uk/gov/hmrc/agentassurance/mocks/MockAgentClientAuthConnector.scala
@@ -14,24 +14,25 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentassurance.services
+package uk.gov.hmrc.agentassurance.mocks
 
-import play.api.Logging
+import org.scalamock.handlers.CallHandler2
+import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.agentassurance.connectors.AgentClientAuthConnector
+import uk.gov.hmrc.agentassurance.models.AgencyDetails
 import uk.gov.hmrc.http.HeaderCarrier
 
-import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
-@Singleton
-class AgencyDetailsService @Inject()(acaConnector: AgentClientAuthConnector
-                                  )(implicit ec: ExecutionContext, hc: HeaderCarrier) extends Logging {
+trait MockAgentClientAuthConnector extends MockFactory {
 
-  def isUkAddress: Future[Boolean] =
-    for {
-      optAgencyDetails <- acaConnector.getAgencyDetails()
-      optAddress = optAgencyDetails.flatMap(_.agencyAddress)
-      countryCodeIsUk = optAddress.exists(_.countryCode == "GB")
-    } yield countryCodeIsUk
+  val mockAcaConnector: AgentClientAuthConnector = mock[AgentClientAuthConnector]
+
+  def mockGetAgencyDetails()(response: Option[AgencyDetails]): CallHandler2[HeaderCarrier, ExecutionContext, Future[Option[AgencyDetails]]] = {
+    (mockAcaConnector.getAgencyDetails()(_: HeaderCarrier, _: ExecutionContext))
+      .expects(*,*)
+      .returning(Future successful response)
+  }
+
 
 }

--- a/test/uk/gov/hmrc/agentassurance/services/AgencyDetailsServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentassurance/services/AgencyDetailsServiceSpec.scala
@@ -1,0 +1,5 @@
+package uk.gov.hmrc.agentassurance.services
+
+class AgencyDetailsServiceSpec {
+
+}

--- a/test/uk/gov/hmrc/agentassurance/services/AgencyDetailsServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentassurance/services/AgencyDetailsServiceSpec.scala
@@ -1,5 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.agentassurance.services
 
-class AgencyDetailsServiceSpec {
+import org.scalatestplus.play.PlaySpec
+import play.api.test.Helpers._
+import uk.gov.hmrc.agentassurance.helpers.TestConstants.{agencyDetailsOverseas, agencyDetailsUk}
+import uk.gov.hmrc.agentassurance.mocks.MockAgentClientAuthConnector
+import uk.gov.hmrc.http.HeaderCarrier
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class AgencyDetailsServiceSpec extends PlaySpec with MockAgentClientAuthConnector {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  val service: AgencyDetailsService = new AgencyDetailsService(mockAcaConnector)
+
+  "isUkAddress" should {
+    "return true if agency address country code is GB" in {
+      mockGetAgencyDetails()(Some(agencyDetailsUk))
+
+      val result = await(service.isUkAddress)
+      result mustBe true
+    }
+
+    "return false if agency address country code is not GB" in {
+      mockGetAgencyDetails()(Some(agencyDetailsOverseas))
+
+      val result = await(service.isUkAddress)
+      result mustBe false
+    }
+
+    "return false if no agency address" in {
+      mockGetAgencyDetails()(None)
+
+      val result = await(service.isUkAddress)
+      result mustBe false
+    }
+  }
 }


### PR DESCRIPTION
If we're unable to find an address stored, we've defaulted to treating them as overseas agents. This behaviour might need to change depending on what we want to happen. Would there be any case where a UK agent wouldn't have an address stored?